### PR TITLE
Fixed the links in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,13 +48,13 @@ If the file `api-primer/halprimer.md` links to the file `api-primer/error-report
 following IS NOT correct:
 
 ```Markdown
-(chapter on Error Reporting)[error-reporting.md]
+[chapter on Error Reporting](error-reporting.md)
 ```
 
 The following IS correct:
 
 ```Markdown
-(chapter on Error Reporting)[/api-primer/error-reporting.md]
+[chapter on Error Reporting](/api-primer/error-reporting.md)
 ```
 
 ### Notes/Warnings/Etc.


### PR DESCRIPTION
I fixed the Markdown links in CONTRIBUTING, the [] parenthesis was inverted with ().
