### PR TITLE
Update first-rest-service.md

### DIFF
--- a/intro/first-rest-service.md
+++ b/intro/first-rest-service.md
@@ -16,7 +16,7 @@ this tutorial. Follow these steps:
 - Within your application root, execute the following:
 
   ```console
-  $ php composer.phar require "zfcampus/statuslib:~1.0-dev"
+  $ php composer.phar require "zfcampus/statuslib-example:dev-master"
   ```
 
 


### PR DESCRIPTION
Fixed typo "zfcampus/statuslib:~1.0-dev" => "zfcampus/statuslib-example:dev-master"
