### PR TITLE
Recipes Editing

### DIFF
--- a/auth/authentication-about.md
+++ b/auth/authentication-about.md
@@ -6,10 +6,10 @@ application can *validate the identity is in fact who they say they are*.  In te
 Apigility, identities are delivered to the application from the client through the use of the
 `Authorization` request header.  This header, if present, is parsed and utilized in one of the
 configured authentication schemes.  If no header is present, Apigility assigns a default identity
-known as a *Guest* identity.  The important thing to note here is that authentication is not
+known as a "guest" identity.  The important thing to note here is that authentication is not
 something that needs to be turned on because *it is always on*. It just needs to be configured to handle when
 an identity is presented to Apigility.  If no authentication scheme is configured, and an identity
-is presented in a way that Apigility cannot handle, or is not configured to handle, the "Guest"
+is presented in a way that Apigility cannot handle, or is not configured to handle, the "guest"
 identity will be assigned.
 
 Apigility delivers three methods to authenticate identities: HTTP Basic authentication, HTTP Digest

--- a/auth/authentication-http-basic.md
+++ b/auth/authentication-http-basic.md
@@ -116,4 +116,4 @@ Important notes:
 - Your client should be capable of properly encoding the HTTP Basic `Authorization` header.
 - In production, ensure a `htpasswd` file can be utilized in the same relative location as in 
   development, even if the `htpasswd` was not checked into your VCS.
-- Omitting the `Authorization` header implies that the "Guest" identity will be used.
+- Omitting the `Authorization` header implies that the "guest" identity will be used.

--- a/auth/authentication-http-digest.md
+++ b/auth/authentication-http-digest.md
@@ -76,4 +76,4 @@ Important notes:
   able to fulfill the digest handshake.
 - In production, ensure a `htdigest` file can be utilized in the same relative location as in 
   development, even if the `htdigest` was not checked into your VCS.
-- No `Authorization` header in the request implies that the "Guest" identity will be used.
+- No `Authorization` header in the request implies that the "guest" identity will be used.

--- a/auth/authorization.md
+++ b/auth/authorization.md
@@ -11,7 +11,7 @@ With Apigility, the information presented through the `Authorization` header is 
 either a `ZF\MvcAuth\Identity\AuthenticatedIdentity` or `ZF\MvcAuth\Identity\GuestIdentity`.  The
 implementation of authorization uses `Zend\Permissions\Acl` as a model of an access control list
 (ACL).  This list is built in the Apigility Admin UI.  By default, everything is accessible to all
-authenticated identities and guest identities.  Apigility does not, by default, give you the ability
+authenticated identities and "guest" identities.  Apigility does not, by default, give you the ability
 to create user groups, or assign specific permissions to specific authenticated users.
 
 Authorization happens post-route, but before dispatch of the requested service.  This is what allows

--- a/recipes/hal-from-rpc.md
+++ b/recipes/hal-from-rpc.md
@@ -43,7 +43,7 @@ class RegisterController extends AbstractActionController
 The [zf-hal](https://github.com/zfcampus/zf-hal) module in Apigility creates the actual HAL
 representations. `zf-hal` looks for a `payload` variable in the view model, and expects that value
 to be either a `ZF\Hal\Entity` (single item) or `ZF\Hal\Collection`. When creating an `Entity`
-object, you need the object being represented, as well as the identifier.  So, let's update our
+object you need the object being represented, as well as the identifier.  So, let's update our
 return value.
 
 ```php
@@ -91,7 +91,7 @@ return array(
 ```
 
 Finally, we need to make sure that the service is configured to actually return HAL. We can do this
-in the admin if we want. Find the "Content Negotiation" section of the admin, and the "Content
+in the admin. Find the "Content Negotiation" section in the admin, then the "Content
 Negotiation Selector" item, and set that to "HalJson"; don't forget to save!
 
 ![Content Negotiation Selector](/asset/apigility-documentation/img/recipes-hal-from-rpc-select-selector.png)
@@ -114,4 +114,4 @@ return array(
 
 Once your changes are complete, when you make a successful request to the URI for your "register"
 RPC service, you'll receive a HAL response pointing to the canonical URI for the user resource
-created!
+created.

--- a/recipes/how-do-i-customize-authorization-for-a-particular-identity.md
+++ b/recipes/how-do-i-customize-authorization-for-a-particular-identity.md
@@ -14,7 +14,7 @@ identity other than "guest" will be part of the system.  It is also important th
 and learned the limitations of the existing authorization setup.
 
 One of the limitations of the current authorization system is that authorization is limited to
-granting access to users based on whether they are an unauthenticated user (which, in Apigility
+granting access to users based on whether they are an unauthenticated user (which, in Apigility,
 goes by the identity "guest") or an authenticated user, whose identity will be stored in the
 `ZF\MvcAuth\Identity\AuthenticatedIdentity` model.
 
@@ -53,7 +53,7 @@ class Module
         $moduleRouteListener = new ModuleRouteListener();
         $moduleRouteListener->attach($eventManager);
         
-        // wire in our listener, at priority 1 to ensure it runs before the
+        // Wire in our listener at priority 1 to ensure it runs before the
         // DefaultAuthorizationListener
         $eventManager->attach(
             MvcAuthEvent::EVENT_AUTHORIZATION,
@@ -65,7 +65,7 @@ class Module
 }
 ```
 
-Lastly, we'll need to construct our listener; comments will describe the code inline:
+Lastly, we'll need to construct our listener.  Refer to the inline comments:
 
 ```php
 namespace Application\Authorization;
@@ -98,7 +98,7 @@ class AuthorizationListener
         $authorization->addRole('ralph');
         
         /**
-         * Now, assign the particular privilidge that this identity needs.
+         * Next, assign the particular privilidge that this identity needs.
          */
         $authorization->allow('ralph', 'FooBar\V1\Rest\Foo\Controller::collection', 'GET');
     }
@@ -106,9 +106,9 @@ class AuthorizationListener
 
 ```
 
-To demonstrate this particular rule in action, consider the following HTTP requests.
+To demonstrate this particular rule in action, consider the following HTTP requests:
 
-First, we'll request without passing any credentials.
+Make a request without passing any credentials.
 
 ```HTTP
 GET /foo HTTP/1.1
@@ -169,7 +169,7 @@ Authorization: Basic cmFscGg6cmFscGg=
 
 ```
 
-Finally, we have success:
+And at long last we have success:
 
 ```HTTP
 HTTP/1.1 200 OK


### PR DESCRIPTION
Editing:  recipes are written very first-person unlike the rest of the code.  Included in this commit is normalization of all guests to "guest" across the documentation.
