### PR TITLE
Add an example for collection in RPC

### DIFF
--- a/recipes/hal-from-rpc.md
+++ b/recipes/hal-from-rpc.md
@@ -66,6 +66,26 @@ class RegisterController extends AbstractActionController
 }
 ```
 
+or for a collection:
+
+```php
+use Zend\Mvc\Controller\AbstractActionController;
+use ZF\ContentNegotiation\ViewModel;
+
+class RegisterController extends AbstractActionController
+{
+    public function registerAction()
+    {
+        /* ... do some work
+         * ... get a $users collection
+         */
+        return new ViewModel(array(
+            'payload' => $this->getPluginManager()->get('hal')->createCollection($users)
+        ));
+    }
+}
+```
+
 > ### The "Payload"
 >
 > When creating a view model to use with `zf-hal`, you must follow a specific convention: the


### PR DESCRIPTION
I couldn't simply return a `new Collection($users)` object within `payload`, I kept getting an error:

``` javascript
{
  status: 500
  title: "Unexpected error"
  describedBy: "http:\/\/www.w3.org\/Protocols\/rfc2616\/rfc2616-sec10.html"
  detail: "Link from resource provided to ZF\\Hal\\Plugin\\Hal::fromLink was incomplete; must contain a URL or a route"
}
```

I was able to get it to work by having the `hal` plugin create the `Hal\Collection` object.
