### PR TITLE
Docs added to zf-apigility-doctrine are not specific to doctrine: add here

### DIFF
--- a/content-negotiation/index.md
+++ b/content-negotiation/index.md
@@ -2,3 +2,35 @@ Content Negotiation
 ===================
 
 Documentation in progress.
+
+Tips
+----
+
+By default, your REST entities will return [HAL-flavored JSON](/api-primer/halprimer.md). If, for
+whatever reason, you want to return vanilla JSON, one trick is to have your entities implement
+`JsonSerializable`. This standard PHP interface defines a single method, `jsonSerialize()`, which
+allows you to return an associative array representation to serialize as JSON. As an example:
+
+```php
+class MyEntity implements \JsonSerializable
+{
+    /* ... */
+
+    public function jsonSerialize()
+    {
+        return array(
+            'name' => $this->getName(),
+        );
+    }
+}
+```
+
+would yield:
+
+```JSON
+{
+  "name": "the name returned from getName()
+}
+```
+
+when cast to JSON.


### PR DESCRIPTION
This PR came through zf-apigility-doctrine but it's not specific to that module so I think it belongs in the documentation:

https://github.com/zfcampus/zf-apigility-doctrine/pull/107/files
