### PR TITLE
fix httpie querystring parameters

### DIFF
--- a/modules/zf-oauth2.md
+++ b/modules/zf-oauth2.md
@@ -233,7 +233,7 @@ an Authorization code. This code must be used to request an OAuth2 token; the
 following HTTPie command provides an example of how to do that:
 
 ```bash
-http --auth testclient:testpass -f POST http://<URL of your ZF2 app>/oauth grant_type=authorization_code&code=YOUR_CODE&redirect_uri=/oauth/receivecode
+http --auth testclient:testpass -f POST http://<URL of your ZF2 app>/oauth grant_type=authorization_code code=YOUR_CODE redirect_uri=/oauth/receivecode
 ```
 
 In client-side scenarios (i.e mobile) where you cannot store the Client


### PR DESCRIPTION
The example does not work. The & separators needs to be escaped on console.

Use the recommended syntax.
https://github.com/jakubroztocil/httpie#user-content-request-items