### PR TITLE
Updated StatusLib registration path

### DIFF
--- a/intro/first-rest-service.md
+++ b/intro/first-rest-service.md
@@ -23,7 +23,7 @@ $ php composer.phar require "zfcampus/statuslib-example:~1.0-dev"
 
 ### Step 2
 
-Edit the file `config/application.config.php` and add the `StatusLib` module:
+Edit the file `config/modules.config.php` and add the `StatusLib` module:
 
 ```php
 array(


### PR DESCRIPTION
Working with the exercises of the site, I notice That the path to add the Status Lib is wrong, it now includes modules.config.php file.