### PR TITLE
PHP-FPM (7.0) with Apache 2.4 via FastCGI Authorization yields a 403  -- FYI doc enhancement

### DIFF
--- a/auth/authentication-oauth2.md
+++ b/auth/authentication-oauth2.md
@@ -511,3 +511,16 @@ with a SQL query:
 ```sql
 DELETE FROM oauth_access_tokens WHERE access_token="<token to remove>";
 ```
+
+
+
+Apache2 FastCGI -- unexpected 403 error for any methods that have the Authorization box ticked
+-------------------
+
+When using Apache2 with the FastCGI module to pass traffic in using PHP-FPM (e.g., you are testing PHP 7.0 with Apache 2.4), the Authentication header is stripped out.
+
+In order to pass in the Authentication: Bearer someAccessTokenGoesHere to PHP, the following command should be added in to the virtual host configuration:
+
+```
+SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+```


### PR DESCRIPTION
This commit is to help some other developer who ends up in the same spot as I was and is trying to figure out why ALL of their authorization-required requests are suddenlly 403 Forbidden responding when the oauth portion is generating access tokens just fine.