### PR TITLE
Update Swagger links

### DIFF
--- a/api-doc/intro.md
+++ b/api-doc/intro.md
@@ -2,7 +2,7 @@ API Documentation
 =================
 
 Apigility offers the ability to generate API documentation using the Admin UI.  The documentation is
-generated in HTML format and, optionally, in [Swagger](https://helloreverb.com/developers/swagger)
+generated in HTML format and, optionally, in [Swagger](https://swagger.io/)
 format. The HTML API documentation is linked in the Apigility UI in the top bar, under the menu item
 "Documentation".
 

--- a/api-doc/swagger.md
+++ b/api-doc/swagger.md
@@ -1,7 +1,7 @@
 How to install the Swagger adapter
 ==================================
 
-To activate the [Swagger](https://helloreverb.com/developers/swagger) adapter for the API
+To activate the [Swagger](https://swagger.io/) adapter for the API
 documentation, you need to require the following dependency by running:
 
 ```bash
@@ -25,6 +25,6 @@ At this point, you can access the Swagger documentation from the welcome screen,
 `Swagger API documentation` button, or by going directly to the `/apigility/swagger` URI (relative
 to your application). The initial page will list available APIs and versions; click the version of
 the API you wish to view, and you will be taken to a 
-[Swagger UI](https://github.com/wordnik/swagger-ui) representation of the API.
+[Swagger UI](https://github.com/swagger-api/swagger-ui) representation of the API.
 
 ![Swagger UI](/asset/apigility-documentation/img/api-doc-swagger-ui.png)


### PR DESCRIPTION
The helloreverb.com site doesn't work anymore.
The GitHub URL redirects to a new address.