### PR TITLE
Fixed typo (missing quote) in module config

### DIFF
--- a/recipes/apigility-in-an-existing-zf2-application.md
+++ b/recipes/apigility-in-an-existing-zf2-application.md
@@ -51,7 +51,7 @@ Now, enable the necessary production modules by editing your `config/application
 
 ```php
     /* ... */
-    'modules => [
+    'modules' => [
         'Application',
         'ZF\Apigility',
         'ZF\Apigility\Provider',


### PR DESCRIPTION
[On your docs](https://apigility.org/documentation/recipes/apigility-in-an-existing-zf2-application), there is a missing quote in the module config. This PR fixes this.